### PR TITLE
Improve Docker Process Logging & Don't use the pants cache for docker process results

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -16,6 +16,8 @@ root_patterns = [
               "/",
               "/test_docker"
               ]
+[sendwave-docker]
+report_progress = true
 
 [python]
 requirement_constraints="constraints.txt"

--- a/pants_plugins/sendwave/pants_docker/package.py
+++ b/pants_plugins/sendwave/pants_docker/package.py
@@ -34,12 +34,13 @@ from pants.engine.environment import Environment, EnvironmentRequest
 from pants.engine.fs import (AddPrefix, CreateDigest, Digest, FileContent,
                              MergeDigests, Snapshot)
 from pants.engine.process import (BinaryPathRequest, BinaryPaths, Process,
-                                  ProcessResult)
+                                  ProcessCacheScope, ProcessResult)
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionMembership
 from sendwave.pants_docker.docker_component import (DockerComponent,
                                                     DockerComponentFieldSet)
+from sendwave.pants_docker.subsystem import Docker
 from sendwave.pants_docker.target import DockerPackageFieldSet
 
 logger = logging.getLogger(__name__)
@@ -107,8 +108,7 @@ def _create_dockerfile(
 
 @rule()
 async def package_into_image(
-    field_set: DockerPackageFieldSet,
-    union_membership: UnionMembership,
+    field_set: DockerPackageFieldSet, union_membership: UnionMembership, docker: Docker
 ) -> BuiltPackage:
     """Build a docker image from a 'docker' build target.
 
@@ -144,13 +144,7 @@ async def package_into_image(
             source_digests.append(component.sources)
         run_commands.extend(component.commands)
     source_digest = await Get(Digest, MergeDigests(source_digests))
-    application_snapshot = await Get(Snapshot, AddPrefix(source_digest, "application"))
-
-    if logger.isEnabledFor(logging.DEBUG):
-        logger.debug("Files to be copied into the docker container")
-        for file in application_snapshot.files:
-            logger.debug("* %s", file)
-
+    application_digest = await Get(Digest, AddPrefix(source_digest, "application"))
     dockerfile_contents = _create_dockerfile(
         field_set.base_image.value,
         field_set.workdir.value,
@@ -158,6 +152,7 @@ async def package_into_image(
         run_commands,
         field_set.command.value,
     )
+
     logger.debug(dockerfile_contents)
     dockerfile = await Get(
         Digest,
@@ -168,7 +163,7 @@ async def package_into_image(
     # and the location of the docker process
     search_path = ["/bin", "/usr/bin", "/usr/local/bin", "$HOME/"]
     docker_context, docker_env, docker_paths = await MultiGet(
-        Get(Digest, MergeDigests([dockerfile, application_snapshot.digest])),
+        Get(Digest, MergeDigests([dockerfile, application_digest])),
         Get(Environment, EnvironmentRequest(utils.DOCKER_ENV_VARS)),
         Get(
             BinaryPaths,
@@ -188,10 +183,11 @@ async def package_into_image(
     )
     # create the image
     process_args = [process_path, "build"]
-    if not logger.isEnabledFor(logging.DEBUG):
-        process_args.append("-q")  # only output the hash of the image
     process_args.extend(tag_arguments)
     process_args.append(".")  # use current (sealed) directory as build context
+    if docker.options.report_progress:
+        process_args.append("--progress")
+        process_args.append("plain")
     process_result = await Get(
         ProcessResult,
         Process(
@@ -199,9 +195,12 @@ async def package_into_image(
             argv=process_args,
             input_digest=docker_context,
             description=f"Creating Docker Image from {target_name}",
+            cache_scope=ProcessCacheScope.PER_SESSION,
         ),
     )
-    logger.info(process_result.stdout.decode())
+    if docker.options.report_progress:
+        logger.info(process_result.stdout.decode())
+        logger.info(process_result.stderr.decode())
     o = await Get(Snapshot, Digest, process_result.output_digest)
     return BuiltPackage(
         digest=process_result.output_digest,

--- a/pants_plugins/sendwave/pants_docker/package.py
+++ b/pants_plugins/sendwave/pants_docker/package.py
@@ -152,8 +152,7 @@ async def package_into_image(
         run_commands,
         field_set.command.value,
     )
-
-    logger.debug(dockerfile_contents)
+    logger.info("Constructed Dockerfile:\n{}".format(dockerfile_contents))
     dockerfile = await Get(
         Digest,
         CreateDigest([FileContent("Dockerfile", dockerfile_contents.encode("utf-8"))]),

--- a/pants_plugins/sendwave/pants_docker/python_requirement.py
+++ b/pants_plugins/sendwave/pants_docker/python_requirement.py
@@ -1,13 +1,13 @@
 from dataclasses import dataclass
 
-from pants.backend.python.target_types import (PythonRequirementsField,
-                                               PythonRequirementsFileSourcesField)
+from pants.backend.python.subsystems.repos import PythonRepos
+from pants.backend.python.subsystems.setup import PythonSetup
+from pants.backend.python.target_types import (
+    PythonRequirementsField, PythonRequirementsFileSourcesField)
 from pants.engine.fs import Digest, PathGlobs
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet
 from pants.engine.unions import UnionRule
-from pants.backend.python.subsystems.repos import PythonRepos
-from pants.backend.python.subsystems.setup import PythonSetup
 from sendwave.pants_docker.docker_component import (DockerComponent,
                                                     DockerComponentFieldSet)
 

--- a/pants_plugins/sendwave/pants_docker/register.py
+++ b/pants_plugins/sendwave/pants_docker/register.py
@@ -1,11 +1,15 @@
+"""Register Sendwave pants-docker plugin rules with the pants build system."""
 import sendwave.pants_docker.package as package
 import sendwave.pants_docker.python_requirement as python_requirement
 import sendwave.pants_docker.sources as sources
+import sendwave.pants_docker.subsystem as subsystem
 import sendwave.pants_docker.target as target
 
 
 def rules():
+    """Collect all pants rules in the plugin."""
     return [
+        *subsystem.rules(),
         *package.rules(),
         *sources.rules(),
         *python_requirement.rules(),
@@ -14,4 +18,5 @@ def rules():
 
 
 def target_types():
+    """Collect the one new target type we've added."""
     return [target.Docker]

--- a/pants_plugins/sendwave/pants_docker/sources.py
+++ b/pants_plugins/sendwave/pants_docker/sources.py
@@ -2,7 +2,8 @@ import logging
 from dataclasses import dataclass
 
 from pants.backend.python.target_types import PythonSourceField
-from pants.core.target_types import (FileSourceField, RelocatedFilesSourcesField,
+from pants.core.target_types import (FileSourceField,
+                                     RelocatedFilesSourcesField,
                                      ResourceSourceField)
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles

--- a/pants_plugins/sendwave/pants_docker/subsystem.py
+++ b/pants_plugins/sendwave/pants_docker/subsystem.py
@@ -1,0 +1,34 @@
+"""Configuration for the Sendwave pants-docker plugin."""
+from pants.engine.rules import SubsystemRule
+from pants.option.subsystem import Subsystem
+
+
+class Docker(Subsystem):
+    """Options for Docker Plugin.
+
+    Allow configuring plugin behavior under the [docker] scope in your
+    pants.toml, or by passing --docker-{option-name} to your command.
+    Available Options:
+
+    report-progress (boolean): if true, log the output of the docker
+        build process.
+    """
+
+    options_scope = "sendwave-docker"
+    help = "Options for Docker Build Process."
+
+    @classmethod
+    def register_options(cls, register):
+        """Register Docker Options with Pants Engine."""
+        super().register_options(register)
+        register(
+            "--report-progress",
+            type=bool,
+            default=False,
+            help="If true: the plugin will report output of `docker build`",
+        )
+
+
+def rules():
+    """Register Docker options as a SubsystemRule."""
+    return [SubsystemRule(Docker)]

--- a/pants_plugins/sendwave/pants_docker/target.py
+++ b/pants_plugins/sendwave/pants_docker/target.py
@@ -6,8 +6,8 @@ from pants.core.goals.package import (BuiltPackage, BuiltPackageArtifact,
 from pants.engine.target import (COMMON_TARGET_FIELDS, Dependencies,
                                  DependenciesRequest, DescriptionField,
                                  HydratedSources, HydrateSourcesRequest,
-                                 StringField, StringSequenceField,
-                                 Tags, Target, Targets, TransitiveTargets,
+                                 StringField, StringSequenceField, Tags,
+                                 Target, Targets, TransitiveTargets,
                                  TransitiveTargetsRequest)
 from pants.engine.unions import UnionRule
 

--- a/pants_plugins/sendwave/pants_docker/test_sources.py
+++ b/pants_plugins/sendwave/pants_docker/test_sources.py
@@ -1,5 +1,7 @@
 import pytest
-from pants.backend.python.target_types import PythonSourceTarget, PythonSourcesGeneratorTarget, PythonTestTarget
+from pants.backend.python.target_types import (PythonSourcesGeneratorTarget,
+                                               PythonSourceTarget,
+                                               PythonTestTarget)
 from pants.backend.python.util_rules import pex_from_targets
 from pants.core.target_types import FileTarget, ResourceTarget
 from pants.engine.addresses import Address
@@ -15,7 +17,12 @@ from sendwave.pants_docker.sources import (DockerFilesFS,
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
-        target_types=[PythonSourcesGeneratorTarget, PythonSourceTarget, FileTarget, ResourceTarget],
+        target_types=[
+            PythonSourcesGeneratorTarget,
+            PythonSourceTarget,
+            FileTarget,
+            ResourceTarget,
+        ],
         rules=[
             *pex_from_targets.rules(),
             *rules(),


### PR DESCRIPTION
We want pants to build a fresh docker image each time (and rely on docker for it's own caching) so this switched the process caching to "SESSION" which means it won't be cached.

Also will log at 'info' level the generated dockerfile & adds the ability to log the docker progress output (which includes timing information!)

Shortcut Story Here: https://app.shortcut.com/sendwaverisk/story/27268/update-pants-docker-plugin-to-not-cache-docker-process-results