### PR TITLE
Fix too-strict interpreter constraints

### DIFF
--- a/README.org
+++ b/README.org
@@ -3,14 +3,14 @@
 #+EMAIL:       engineering@sendwave.com
 #+DESCRIPTION: Docker Plugin Documentation
 
-* Version 1.1.0
+* Version 1.1.1
 
 This package contains an implementation of a plugin for the [[https://www.pantsbuild.org/][pants
 build system]] to build docker images from pants build targets.
 
 * Requirements
 
-This plugin supports pantsbuild 2.13 and requires python 3.9 to be
+This plugin supports pantsbuild 2.13 and requires python >=3.8 to be
 installed, as well as transitively any other pants dependencies.
 
 * Installation
@@ -50,6 +50,8 @@ DockerComponent dataclass. Then add a
 the DockerComponent will be copied into the image and the =commands=
 will be executed in the generated DockerFile.
 * ChangeLog
+* 1.1.1
++ Fix too strict python interpreter version to allow any python version 3.8 or greater
 * 1.1.0
 + Update plugin for compatibility with pants version 2.13
 + No user facing changes, but changes how lockfiles set via `requirement_constraints` are handled

--- a/pants.toml
+++ b/pants.toml
@@ -29,7 +29,7 @@ search_path = ["<PYENV>"]
 [python]
 tailor_pex_binary_targets = false
 requirement_constraints = "constraints.txt"
-interpreter_constraints = ["==3.9.*"]
+interpreter_constraints = [">=3.8"]
 
 
 [anonymous-telemetry]

--- a/pants_plugins/sendwave/pants_docker/BUILD
+++ b/pants_plugins/sendwave/pants_docker/BUILD
@@ -13,7 +13,7 @@ python_distribution(
     ],
     provides=setup_py(
         name="sendwave-pants-docker",
-        version="1.1.0",
+        version="1.1.1",
         description="Pants Plugin to automatically generate docker images from pants targets",
         url="https://github.com/waveremit/pants-docker",
         author="Nathan Rosenbloom, Jean Cochrane",


### PR DESCRIPTION
I didn't realize that changing the interpreter constraints in pants.toml would change what python versions the plugin is allowed to be installed under - I thought it just changed what version of python pants used! oh well! this will get hotfixed into version 1.1.1