### PR TITLE
Add cache_from option and bump to 1.1.2

### DIFF
--- a/README.org
+++ b/README.org
@@ -74,6 +74,8 @@ will be executed in the generated DockerFile.
 * ChangeLog
 * 1.1.2
 + Add support for cache_from field to configure remote caches via `docker build --cache-from`
++ Add support for buildkit_inline_cache field to set `--build-arg BUILDKIT_INLINE_CACHE=1`
++ Add support for multiline_pip_install field to `RUN pip install` on multiple lines (one per dependency) or one line for all dependencies
 * 1.1.1
 + Fix too strict python interpreter version to allow any python version 3.8 or greater
 * 1.1.0

--- a/README.org
+++ b/README.org
@@ -75,7 +75,7 @@ will be executed in the generated DockerFile.
 * 1.1.2
 + Add support for cache_from field to configure remote caches via `docker build --cache-from`
 + Add support for buildkit_inline_cache field to set `--build-arg BUILDKIT_INLINE_CACHE=1`
-+ Add support for multiline_pip_install field to `RUN pip install` on multiple lines (one per dependency) or one line for all dependencies
++ Add support for multiline_pip_install option to `RUN pip install` on multiple lines (one per dependency) or one line for all dependencies
 * 1.1.1
 + Fix too strict python interpreter version to allow any python version 3.8 or greater
 * 1.1.0

--- a/README.org
+++ b/README.org
@@ -51,7 +51,7 @@ the DockerComponent will be copied into the image and the =commands=
 will be executed in the generated DockerFile.
 * ChangeLog
 * 1.1.2
-+ Add support for cache_from option to configure remote caches via `docker build --cache-from`
++ Add support for cache_from field to configure remote caches via `docker build --cache-from`
 * 1.1.1
 + Fix too strict python interpreter version to allow any python version 3.8 or greater
 * 1.1.0

--- a/README.org
+++ b/README.org
@@ -3,7 +3,7 @@
 #+EMAIL:       engineering@sendwave.com
 #+DESCRIPTION: Docker Plugin Documentation
 
-* Version 1.1.1
+* Version 1.1.2
 
 This package contains an implementation of a plugin for the [[https://www.pantsbuild.org/][pants
 build system]] to build docker images from pants build targets.
@@ -50,6 +50,8 @@ DockerComponent dataclass. Then add a
 the DockerComponent will be copied into the image and the =commands=
 will be executed in the generated DockerFile.
 * ChangeLog
+* 1.1.2
++ Add support for cache_from option to configure remote caches via `docker build --cache-from`
 * 1.1.1
 + Fix too strict python interpreter version to allow any python version 3.8 or greater
 * 1.1.0

--- a/README.org
+++ b/README.org
@@ -43,6 +43,24 @@ the generated imaage.
 See =$ pants help docker= for information on possible values for the
 docker target.
 
+* Using external layer cache sources
+Images built with this plugin can be configured for
+[[https://docs.docker.com/engine/reference/commandline/build/#specifying-external-cache-sources][external layer cache sources]]
+via the =build_cache= and =buildkit_inline_cache= fields on the
+=docker= target. Note that both of these fields require
+[[https://docs.docker.com/develop/develop-images/build_enhancements/][BuildKit]]
+to be installed.
+
+To enable writing inline layer caches for an image, set the field
+=buildkit_inline_cache=True= on the target. If you would like to use
+the built image as an external cache, tag it after packaging and push
+it to a remote repository using =docker tag= and =docker push=.
+
+To enable reading inline layer caches for an image, including from
+external cache sources, set the field =build_cache=<your-image-cache>=
+on the target.
+
+* Developing plugins
 To add support for more targets in subsequent plugins (i.e. to
 plug-into this plugin) add a rule mapping your Target/FieldSet to a
 DockerComponent dataclass. Then add a

--- a/README.org
+++ b/README.org
@@ -58,7 +58,11 @@ it to a remote repository using =docker tag= and =docker push=.
 
 To enable reading inline layer caches for an image, including from
 external cache sources, set the field =build_cache=<your-image-cache>=
-on the target.
+on the target. If you're reading a cache from a private registry, you
+will also have to pass your Docker config file into the pants process
+so that pants knows how to authenticate your cache pull request; the
+easiest way to do this is simply to set the =DOCKER_CONFIG= environment
+variable for the pants process, e.g. =DOCKER_CONFIG="$HOME/.docker" ./pants package ...=.
 
 * Developing plugins
 To add support for more targets in subsequent plugins (i.e. to

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -4,3 +4,6 @@ colors = true
 
 [pytest]
 args = ["-vv"]
+
+[sendwave-docker]
+cache_from = "us-docker.pkg.dev/sendwave-development/sendwave-docker/pants-docker"

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -4,6 +4,3 @@ colors = true
 
 [pytest]
 args = ["-vv"]
-
-[sendwave-docker]
-cache_from = "us-docker.pkg.dev/sendwave-development/sendwave-docker/pants-docker"

--- a/pants.toml
+++ b/pants.toml
@@ -21,7 +21,6 @@ root_patterns = [
               ]
 [sendwave-docker]
 report_progress = true
-cache_from = "us-docker.pkg.dev/sendwave-development/sendwave-docker/pants-docker"
 
 [python-bootstrap]
 search_path = ["<PYENV>"]

--- a/pants.toml
+++ b/pants.toml
@@ -21,6 +21,7 @@ root_patterns = [
               ]
 [sendwave-docker]
 report_progress = true
+cache_from = "us-docker.pkg.dev/sendwave-development/sendwave-docker/pants-docker"
 
 [python-bootstrap]
 search_path = ["<PYENV>"]

--- a/pants_plugins/sendwave/pants_docker/BUILD
+++ b/pants_plugins/sendwave/pants_docker/BUILD
@@ -13,7 +13,7 @@ python_distribution(
     ],
     provides=setup_py(
         name="sendwave-pants-docker",
-        version="1.1.1",
+        version="1.1.2",
         description="Pants Plugin to automatically generate docker images from pants targets",
         url="https://github.com/waveremit/pants-docker",
         author="Nathan Rosenbloom, Jean Cochrane",

--- a/pants_plugins/sendwave/pants_docker/package.py
+++ b/pants_plugins/sendwave/pants_docker/package.py
@@ -57,36 +57,33 @@ from sendwave.pants_docker.target import DockerPackageFieldSet
 logger = logging.getLogger(__name__)
 
 
-def _build_tags(
-    target_name: str, tags: List[str], registry: Optional[str]
-) -> List[str]:
+def _build_full_target_name(target_name: str, registry: Optional[str]) -> str:
+    """Generate a Docker target name that specifies an optional registry, if one exists."""
+    return f"{registry}/{target_name}" if registry else target_name
+
+
+def _build_tags(target_name: str, tags: List[str]) -> List[str]:
     """Build a list of docker tags.
 
     Each tag in the passed in list will be formatted as:
-    {registry/}target_name:tag in order to tag a docker image
+    target_name:tag in order to tag a docker image
     """
-    tags = [f"{target_name}:{tag}" for tag in tags]
-    tags.append(target_name)
-    if not registry:
-        return tags
-    return [f"{registry}/{tag}" for tag in tags]
+    return [f"{target_name}:{tag}" for tag in tags] + [target_name]
 
 
-def _build_tag_argument_list(
-    target_name: str, tags: List[str], registry: Optional[str]
-) -> List[str]:
+def _build_tag_argument_list(target_name: str, tags: List[str]) -> List[str]:
     """Build a list of docker tags and format them as CLI arguments.
 
     Takes the name of the build artifact, a list of tags and an
     optional docker registry and formats them as arguments to the
     docker command line program. Adding a "-t" before each formatted
-    "registry/name:tag
+    name:tag
 
     i.e. ('test_container, ['version]) -> ["-t", "test-container:version"]
 
     If the 'tags' list is empty no tags will be produced
     """
-    tags = _build_tags(target_name, tags, registry)
+    tags = _build_tags(target_name, tags)
     tags = itertools.chain(*(("-t", tag) for tag in tags))
     return list(tags)
 
@@ -223,16 +220,36 @@ async def package_into_image(
     process_path = docker_paths.first_path.path
     # build an list of arguments of the form ["-t",
     # "registry/name:tag"] to pass to the docker executable
+    full_target_name = _build_full_target_name(
+        target_name, field_set.registry.value
+    )
     tag_arguments = _build_tag_argument_list(
-        target_name, field_set.tags.value or [], field_set.registry.value
+        full_target_name, field_set.tags.value or []
     )
     # create the image
-    process_args = [process_path, "build"]
+    # We need to enable BuildKit if we plan to read and write to a remote cache
+    cli_command = (
+        ["buildx", "build"] if docker.options.cache_from else ["build"]
+    )
+    process_args = [process_path] + cli_command
     process_args.extend(tag_arguments)
     process_args.append(".")  # use current (sealed) directory as build context
     if docker.options.report_progress:
         process_args.append("--progress")
         process_args.append("plain")
+    if docker.options.cache_from:
+        registry_separator = (
+            "" if docker.options.cache_from.endswith("/") else "/"
+        )
+        cache_registry = (
+            f"{docker.options.cache_from}{registry_separator}{full_target_name}"
+        )
+        process_args += [
+            "--build-arg",
+            "BUILDKIT_INLINE_CACHE=1",
+            "--cache-from",
+            cache_registry,
+        ]
     process_result = await Get(
         ProcessResult,
         Process(

--- a/pants_plugins/sendwave/pants_docker/package.py
+++ b/pants_plugins/sendwave/pants_docker/package.py
@@ -162,6 +162,7 @@ async def package_into_image(
 
     pip_requirements_component = await Get(
         DockerComponent,
+        DockerComponentFieldSet,
         PythonRequirementsFS(requirements=tuple(pip_requirement_targets)),
     )
 

--- a/pants_plugins/sendwave/pants_docker/package.py
+++ b/pants_plugins/sendwave/pants_docker/package.py
@@ -185,9 +185,7 @@ async def package_into_image(
         component_list.append(
             Get(
                 DockerComponent,
-                PythonRequirements(
-                    requirements=tuple(pip_requirement_targets)
-                ),
+                PythonRequirements(requirements=tuple(pip_requirement_targets)),
             )
         )
 

--- a/pants_plugins/sendwave/pants_docker/package.py
+++ b/pants_plugins/sendwave/pants_docker/package.py
@@ -54,8 +54,8 @@ from sendwave.pants_docker.docker_component import (
     DockerComponentFieldSet,
 )
 from sendwave.pants_docker.python_requirement import (
-    MultilinePythonRequirementsFS,
-    PythonRequirementsFS,
+    MultilinePythonRequirements,
+    PythonRequirements,
     VirtualEnvRequest,
 )
 from sendwave.pants_docker.subsystem import Docker
@@ -186,14 +186,14 @@ async def package_into_image(
         if field_set.multiline_pip_install.value:
             pip_requirements_component = Get(
                 DockerComponent,
-                MultilinePythonRequirementsFS(
+                MultilinePythonRequirements(
                     requirements=tuple(pip_requirement_targets)
                 ),
             )
         else:
             pip_requirements_component = Get(
                 DockerComponent,
-                PythonRequirementsFS(
+                PythonRequirements(
                     requirements=tuple(pip_requirement_targets)
                 ),
             )

--- a/pants_plugins/sendwave/pants_docker/package.py
+++ b/pants_plugins/sendwave/pants_docker/package.py
@@ -54,7 +54,6 @@ from sendwave.pants_docker.docker_component import (
     DockerComponentFieldSet,
 )
 from sendwave.pants_docker.python_requirement import (
-    MultilinePythonRequirements,
     PythonRequirements,
     VirtualEnvRequest,
 )
@@ -183,21 +182,14 @@ async def package_into_image(
                 pip_requirement_targets.append(value)
 
     if pip_requirement_targets:
-        if field_set.multiline_pip_install.value:
-            pip_requirements_component = Get(
-                DockerComponent,
-                MultilinePythonRequirements(
-                    requirements=tuple(pip_requirement_targets)
-                ),
-            )
-        else:
-            pip_requirements_component = Get(
+        component_list.append(
+            Get(
                 DockerComponent,
                 PythonRequirements(
                     requirements=tuple(pip_requirement_targets)
                 ),
             )
-        component_list.append(pip_requirements_component)
+        )
 
     for field_set_type in union_membership[DockerComponentFieldSet]:
         for target in transitive_targets.dependencies:

--- a/pants_plugins/sendwave/pants_docker/python_requirement.py
+++ b/pants_plugins/sendwave/pants_docker/python_requirement.py
@@ -68,7 +68,10 @@ class PythonRequirements:
 
 @rule
 async def get_requirements(
-    field_set: PythonRequirements, setup: PythonSetup, repos: PythonRepos, docker: Docker,
+    field_set: PythonRequirements,
+    setup: PythonSetup,
+    repos: PythonRepos,
+    docker: Docker,
 ) -> DockerComponent:
     install_args = _get_install_args(setup, repos)
     if docker.options.multiline_pip_install:

--- a/pants_plugins/sendwave/pants_docker/python_requirement.py
+++ b/pants_plugins/sendwave/pants_docker/python_requirement.py
@@ -98,13 +98,13 @@ def _get_install_args(
 
 
 @dataclass(frozen=True)
-class PythonRequirementsFS:
+class PythonRequirements:
     requirements: Tuple[PythonRequirementsField]
 
 
 @rule
 async def get_requirements(
-    field_set: PythonRequirementsFS, setup: PythonSetup, repos: PythonRepos
+    field_set: PythonRequirements, setup: PythonSetup, repos: PythonRepos
 ) -> DockerComponent:
     install_args = _get_install_args(setup, repos)
     commands = (
@@ -120,13 +120,13 @@ async def get_requirements(
 
 
 @dataclass(frozen=True)
-class MultilinePythonRequirementsFS:
+class MultilinePythonRequirements:
     requirements: Tuple[PythonRequirementsField]
 
 
 @rule
 def get_multiline_requirements(
-    field_set: MultilinePythonRequirementsFS,
+    field_set: MultilinePythonRequirements,
     setup: PythonSetup,
     repos: PythonRepos,
 ) -> DockerComponent:

--- a/pants_plugins/sendwave/pants_docker/python_requirement.py
+++ b/pants_plugins/sendwave/pants_docker/python_requirement.py
@@ -66,8 +66,7 @@ async def create_virtual_env(
 
 
 @dataclass(frozen=True)
-class PythonRequirementsFS(FieldSet):
-    required_fields = (PythonRequirementsField,)
+class PythonRequirementsFS:
     requirements: Tuple[PythonRequirementsField]
 
 

--- a/pants_plugins/sendwave/pants_docker/subsystem.py
+++ b/pants_plugins/sendwave/pants_docker/subsystem.py
@@ -24,6 +24,12 @@ class Docker(Subsystem):
         help="If true: the plugin will report output of `docker build`",
     )
 
+    multiline_pip_install = BoolOption(
+        "--multiline-pip-install",
+        default=False,
+        help="If true: the plugin will `pip install` each requirement on its own line",
+    )
+
 
 def rules():
     """Register Docker options as a SubsystemRule."""

--- a/pants_plugins/sendwave/pants_docker/subsystem.py
+++ b/pants_plugins/sendwave/pants_docker/subsystem.py
@@ -23,11 +23,6 @@ class Docker(Subsystem):
         default=False,
         help="If true: the plugin will report output of `docker build`",
     )
-    multiline_pip_install = BoolOption(
-        "--multiline-pip-install",
-        default=True,
-        help="If true: the plugin will `pip install` each requirement on its own line",
-    )
 
 
 def rules():

--- a/pants_plugins/sendwave/pants_docker/subsystem.py
+++ b/pants_plugins/sendwave/pants_docker/subsystem.py
@@ -1,6 +1,6 @@
 """Configuration for the Sendwave pants-docker plugin."""
 from pants.engine.rules import SubsystemRule
-from pants.option.option_types import BoolOption
+from pants.option.option_types import BoolOption, StrOption
 from pants.option.subsystem import Subsystem
 
 
@@ -22,6 +22,15 @@ class Docker(Subsystem):
         "--report-progress",
         default=False,
         help="If true: the plugin will report output of `docker build`",
+    )
+
+    cache_from = StrOption(
+        "--cache-from",
+        default=None,
+        help=(
+            "Specify a registry that will be used for caching via the "
+            "docker build --cache-from option (requires BuildKit to be installed)"
+        ),
     )
 
 

--- a/pants_plugins/sendwave/pants_docker/subsystem.py
+++ b/pants_plugins/sendwave/pants_docker/subsystem.py
@@ -1,6 +1,6 @@
 """Configuration for the Sendwave pants-docker plugin."""
 from pants.engine.rules import SubsystemRule
-from pants.option.option_types import BoolOption, StrOption
+from pants.option.option_types import BoolOption
 from pants.option.subsystem import Subsystem
 
 
@@ -22,15 +22,6 @@ class Docker(Subsystem):
         "--report-progress",
         default=False,
         help="If true: the plugin will report output of `docker build`",
-    )
-
-    cache_from = StrOption(
-        "--cache-from",
-        default=None,
-        help=(
-            "Specify a registry that will be used for caching via the "
-            "docker build --cache-from option (requires BuildKit to be installed)"
-        ),
     )
 
 

--- a/pants_plugins/sendwave/pants_docker/subsystem.py
+++ b/pants_plugins/sendwave/pants_docker/subsystem.py
@@ -23,6 +23,11 @@ class Docker(Subsystem):
         default=False,
         help="If true: the plugin will report output of `docker build`",
     )
+    multiline_pip_install = BoolOption(
+        "--multiline-pip-install",
+        default=True,
+        help="If true: the plugin will `pip install` each requirement on its own line",
+    )
 
 
 def rules():

--- a/pants_plugins/sendwave/pants_docker/target.py
+++ b/pants_plugins/sendwave/pants_docker/target.py
@@ -78,6 +78,13 @@ class BuildkitInlineCache(BoolField):
     )
 
 
+class MultilinePipInstall(BoolField):
+    alias = "multiline_pip_install"
+    required = False
+    default = False
+    help = "If true: the plugin will `pip install` each requirement on its own line"
+
+
 class Tags(StringSequenceField):
     alias = "tags"
     default = []
@@ -103,6 +110,7 @@ class DockerPackageFieldSet(pants.core.goals.package.PackageFieldSet):
     registry: Registry
     cache_from: CacheFrom
     buildkit_inline_cache: BuildkitInlineCache
+    multiline_pip_install: MultilinePipInstall
     tags: Tags
     dependencies: Dependencies
     workdir: WorkDir
@@ -124,6 +132,7 @@ class Docker(Target):
         Command,
         CacheFrom,
         BuildkitInlineCache,
+        MultilinePipInstall,
     )
 
 

--- a/pants_plugins/sendwave/pants_docker/target.py
+++ b/pants_plugins/sendwave/pants_docker/target.py
@@ -8,6 +8,7 @@ from pants.core.goals.package import (
 )
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
+    BoolField,
     Dependencies,
     DependenciesRequest,
     DescriptionField,
@@ -67,6 +68,16 @@ class CacheFrom(StringField):
     )
 
 
+class BuildkitInlineCache(BoolField):
+    alias = "buildkit_inline_cache"
+    required = False
+    default = False
+    help = (
+        "Enables writing an inline layer cache for the image via the docker build --build-arg "
+        "BUILDKIT_INLINE_CACHE=1 parameter (requires BuildKit to be installed)"
+    )
+
+
 class Tags(StringSequenceField):
     alias = "tags"
     default = []
@@ -91,6 +102,7 @@ class DockerPackageFieldSet(pants.core.goals.package.PackageFieldSet):
     ignore: DockerIgnore
     registry: Registry
     cache_from: CacheFrom
+    buildkit_inline_cache: BuildkitInlineCache
     tags: Tags
     dependencies: Dependencies
     workdir: WorkDir
@@ -111,6 +123,7 @@ class Docker(Target):
         Tags,
         Command,
         CacheFrom,
+        BuildkitInlineCache,
     )
 
 

--- a/pants_plugins/sendwave/pants_docker/target.py
+++ b/pants_plugins/sendwave/pants_docker/target.py
@@ -57,6 +57,16 @@ class Registry(StringField):
     help = "The registry of the resulting docker image"
 
 
+class CacheFrom(StringField):
+    alias = "cache_from"
+    required = False
+    default = None
+    help = (
+        "Specify a registry that will be used for caching via the "
+        "docker build --cache-from option (requires BuildKit to be installed)"
+    )
+
+
 class Tags(StringSequenceField):
     alias = "tags"
     default = []
@@ -80,6 +90,7 @@ class DockerPackageFieldSet(pants.core.goals.package.PackageFieldSet):
     image_setup: ImageSetup
     ignore: DockerIgnore
     registry: Registry
+    cache_from: CacheFrom
     tags: Tags
     dependencies: Dependencies
     workdir: WorkDir
@@ -99,6 +110,7 @@ class Docker(Target):
         WorkDir,
         Tags,
         Command,
+        CacheFrom,
     )
 
 

--- a/pants_plugins/sendwave/pants_docker/target.py
+++ b/pants_plugins/sendwave/pants_docker/target.py
@@ -78,13 +78,6 @@ class BuildkitInlineCache(BoolField):
     )
 
 
-class MultilinePipInstall(BoolField):
-    alias = "multiline_pip_install"
-    required = False
-    default = False
-    help = "If true: the plugin will `pip install` each requirement on its own line"
-
-
 class Tags(StringSequenceField):
     alias = "tags"
     default = []
@@ -110,7 +103,6 @@ class DockerPackageFieldSet(pants.core.goals.package.PackageFieldSet):
     registry: Registry
     cache_from: CacheFrom
     buildkit_inline_cache: BuildkitInlineCache
-    multiline_pip_install: MultilinePipInstall
     tags: Tags
     dependencies: Dependencies
     workdir: WorkDir
@@ -132,7 +124,6 @@ class Docker(Target):
         Command,
         CacheFrom,
         BuildkitInlineCache,
-        MultilinePipInstall,
     )
 
 

--- a/test_docker/BUILD
+++ b/test_docker/BUILD
@@ -40,5 +40,4 @@ docker(
         "//:test_docker_reqs#gevent",
     ],
     buildkit_inline_cache=True,
-    multiline_pip_install=False,
 )

--- a/test_docker/BUILD
+++ b/test_docker/BUILD
@@ -40,4 +40,5 @@ docker(
         "//:test_docker_reqs#gevent",
     ],
     buildkit_inline_cache=True,
+    multiline_pip_install=False,
 )

--- a/test_docker/BUILD
+++ b/test_docker/BUILD
@@ -39,4 +39,5 @@ docker(
         "//:test_docker_reqs#gunicorn",
         "//:test_docker_reqs#gevent",
     ],
+    buildkit_inline_cache=True,
 )


### PR DESCRIPTION
This PR adds a new subsystem option `cache_from` that allows developers to specify a string representing the location of the cache registry.

I confirmed this works by pushing up a test image to a remote registry and setting the `cache_from` field on the `dockerized_flask_app` target:

```
$ ./pants package test_docker:dockerized_flask_app
...
#5 importing cache manifest from us-docker.pkg.dev/sendwave-development/sendwave-docker/pants-docker/dockerized_flask_app
#5 DONE 0.0s

#6 [internal] load build context
#6 transferring context: 122.70kB done
#6 DONE 0.0s

#7 [ 7/11] RUN python -m pip install --upgrade pip -c constraints.txt
#7 CACHED
...
```

I also tested the `multiline_pip_install` option by setting it to `True` and `False` and confirming the output.

With `multiline_pip_install=False`:

```
$ ./pants --no-pantsd --print-stacktrace package test_docker:dockerized_flask_app 
11:58:33.65 [INFO] Constructed Dockerfile:
FROM python:3.8.8-slim-buster
WORKDIR root
RUN apt-get update && apt-get upgrade --yes
RUN apt-get -y install gcc libpq-dev
COPY application/constraints.txt .
RUN python -m venv --upgrade /.virtual_env
ENV PATH=/.virtual_env/bin:$PATH
ENV VIRTUAL_ENV=/.virtual_env
RUN python -m pip install --upgrade pip -c constraints.txt
RUN python -m pip install --index-url https://pypi.org/simple/  --constraint constraints.txt gevent==21.12.0 gunicorn==20.1.0 flask==2.0.3
COPY application .
CMD ["/.virtual_env/bin/gunicorn","--bind=127.0.0.1:8000","test_docker.app:app"]
...
```

And with `multiline_pip_install=True`:

```
$ ./pants --no-pantsd --print-stacktrace package test_docker:dockerized_flask_app                
11:59:04.53 [INFO] Constructed Dockerfile:
FROM python:3.8.8-slim-buster
WORKDIR root
RUN apt-get update && apt-get upgrade --yes
RUN apt-get -y install gcc libpq-dev
COPY application/constraints.txt .
RUN python -m venv --upgrade /.virtual_env
ENV PATH=/.virtual_env/bin:$PATH
ENV VIRTUAL_ENV=/.virtual_env
RUN python -m pip install --upgrade pip -c constraints.txt
RUN python -m pip install --index-url https://pypi.org/simple/  --constraint constraints.txt gevent==21.12.0
RUN python -m pip install --index-url https://pypi.org/simple/  --constraint constraints.txt gunicorn==20.1.0
RUN python -m pip install --index-url https://pypi.org/simple/  --constraint constraints.txt flask==2.0.3
COPY application .
CMD ["/.virtual_env/bin/gunicorn","--bind=127.0.0.1:8000","test_docker.app:app"]
...